### PR TITLE
POSIX mandates to check TMPDIR + minor improvements

### DIFF
--- a/tests/parameter.cpp
+++ b/tests/parameter.cpp
@@ -46,7 +46,7 @@ template <typename T>
 void writeToParameterFile(const painless::Parameter<T>& parameter,
                           const std::string& content) {
   {
-    std::string path = painless::BASE_PATH;
+    std::string path = painless::get_base_path();
     path += parameter.name();
     std::ofstream f(path);
     f << content << "\n";


### PR DESCRIPTION
While you can always assume `/tmp` to be available, POSIX mandates that you check the `TMPDIR` environment variable as a preference for temporary files and directories [1].

For the minor improvements: `mkdir` might fail and has to be handled somehow.  I chose to throw an exception, but an implementation where you fall back to `tmpfile` [2] is also conceivable.

A lot of the `template <>` specialization for function templates are not needed.  They can just be replaced by regular overloads.

An `inline` was missing, possibly leading to linkage problems.

[1] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_03
[2] https://linux.die.net/man/3/tmpfile